### PR TITLE
Add Support for PHP 8.

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     },
     "license": "MIT",
     "require": {
-        "php": "^7.0",
-        "traderinteractive/exceptions": "^1.0"
+        "php": "^7.3 || ^8.0",
+        "traderinteractive/exceptions": "^2.0"
     },
     "suggest": {
         "ext-timezonedb": "The latest version of the timezone database"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^9.0",
         "squizlabs/php_codesniffer": "^3.2"
     },
     "autoload": {

--- a/tests/DateTimeTest.php
+++ b/tests/DateTimeTest.php
@@ -49,13 +49,13 @@ final class DateTimeTest extends TestCase
      *
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value is not a non-empty string
      *
      * @return void
      */
     public function filterEmptyValue()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value is not a non-empty string');
         DateTime::filter("\t \n");
     }
 
@@ -64,13 +64,13 @@ final class DateTimeTest extends TestCase
      *
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value is not a non-empty string
      *
      * @return void
      */
     public function filterInvalidValue()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value is not a non-empty string');
         DateTime::filter(true);
     }
 
@@ -90,11 +90,11 @@ final class DateTimeTest extends TestCase
      *
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value failed filtering, $allowNull is set to false
      */
     public function filterNullNotAllowed()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('Value failed filtering, $allowNull is set to false');
         DateTime::filter(null, false);
     }
 
@@ -154,12 +154,11 @@ final class DateTimeTest extends TestCase
      *
      * @test
      * @covers ::format
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage $format is not a non-empty string
      */
     public function formatWithEmptyFormat()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$format is not a non-empty string');
         $now = new \DateTime();
         $this->assertSame($now->format('Y-m-d H:i:s'), DateTime::format($now, '          '));
     }

--- a/tests/DateTimeZoneTest.php
+++ b/tests/DateTimeZoneTest.php
@@ -46,13 +46,13 @@ final class DateTimeZoneTest extends TestCase
      *
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Value failed filtering, $allowNull is set to false
      *
      * @return void
      */
     public function filterNullNotAllowed()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('Value failed filtering, $allowNull is set to false');
         $this->assertNull(DateTimeZone::filter(null, false));
     }
 
@@ -75,11 +75,11 @@ final class DateTimeZoneTest extends TestCase
      *
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage Unknown or bad timezone (INVALID)
      */
     public function filterInvalidName()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('Unknown or bad timezone (INVALID)');
         DateTimeZone::filter('INVALID');
     }
 
@@ -88,13 +88,13 @@ final class DateTimeZoneTest extends TestCase
      *
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value not a non-empty string
      *
      * @return void
      */
     public function filterEmptyValue()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value not a non-empty string');
         DateTimeZone::filter("\n\t");
     }
 
@@ -103,13 +103,13 @@ final class DateTimeZoneTest extends TestCase
      *
      * @test
      * @covers ::filter
-     * @expectedException \TraderInteractive\Exceptions\FilterException
-     * @expectedExceptionMessage $value not a non-empty string
      *
      * @return void
      */
     public function filterNonStringArgument()
     {
+        $this->expectException(\TraderInteractive\Exceptions\FilterException::class);
+        $this->expectExceptionMessage('$value not a non-empty string');
         DateTimeZone::filter(42);
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Add Support for PHP 8.
Backwards breaking; Remove Support for PHP 7.2 and earlier.
Upgrade to PHPUnit 9.

#### Checklist
- [  ] Pull request contains a clear definition of changes
- [  ] Tests (either unit, integration, or acceptance) written and passing
- [  ] Relevant documentation produced and/or updated

